### PR TITLE
Hid the solve button

### DIFF
--- a/puzzles/static/puzzles/css/slider_puzzle.css
+++ b/puzzles/static/puzzles/css/slider_puzzle.css
@@ -125,7 +125,7 @@
 /* Button Styles */
 #solve-button {
     /* Hide the solve button from Nightingale */
-    display: inline;
+    display: none;
 }
 
 .slider-puzzle-buttons {


### PR DESCRIPTION
The solve button was to re-arrange the slider-puzzle board so as to solve it and check and debug, if required, the page on completion of the puzzle. That button shouldn't be shown to Nightingale. Hence, simply display was changed to none in the css file.